### PR TITLE
fix: update URLs after org rename from 4lando to lando-community

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is currently a work in progress but should properly validate most common
 Landofile configurations.
 
 If your IDE supports schemas from SchemaStore.org, this schema is already available to you as `Lando (landofile)`, otherwise
-access it directly at https://4lando.github.io/lando-spec/landofile-spec.json
+access it directly at https://lando-community.github.io/lando-spec/landofile-spec.json
 
 See it demonstrated in the [Landofile editor](https://editor.4lando.dev) which uses this schema for its validation.
 


### PR DESCRIPTION
The `4lando` GitHub org was renamed to `lando-community`. While GitHub redirects repository URLs automatically, **GitHub Pages URLs do not redirect** — meaning `4lando.github.io` returns 404.

This updates all references from `4lando` to `lando-community` to fix broken URLs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a broken GitHub Pages link; no runtime or schema logic is affected.
> 
> **Overview**
> Updates the README’s direct schema URL to use the new `lando-community.github.io` GitHub Pages domain (replacing `4lando.github.io`) so the Landofile schema link no longer 404s after the org rename.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28eb46fbc4d4f038a8647b293ff78dccf9874a65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->